### PR TITLE
Flag DynamicEnumFrame as unsane when cursor enters

### DIFF
--- a/widgets/field_widgets/enum_frame.py
+++ b/widgets/field_widgets/enum_frame.py
@@ -224,6 +224,8 @@ class DynamicEnumFrame(EnumFrame):
 
         self.sel_menu.bind('<FocusIn>', self.flag_sanity_change)
         self.sel_menu.arrow_button.bind('<FocusIn>', self.flag_sanity_change)
+        self.sel_menu.bind('<Enter>', self.flag_sanity_change)
+        self.sel_menu.arrow_button.bind('<Enter>', self.flag_sanity_change)
         self.sel_menu.options_volatile = 'DYN_NAME_PATH' in self.desc
 
         if self.gui_name != '':


### PR DESCRIPTION
I understand that this is the intended behavior of the usage of the <FocusIn> event as you still have to click the enum for the population function to actually execute.

This should definitively fix the enum bug.