### PR TITLE
Implement GUI scaling

### DIFF
--- a/binilla/widgets/binilla_widget.py
+++ b/binilla/widgets/binilla_widget.py
@@ -12,7 +12,7 @@ from binilla.widgets import style_change_lock, font_config
 
 __all__ = ("BinillaWidget", )
 
-
+WIDGET_SCALING = 1.333
 
 class BinillaWidget():
     '''
@@ -179,6 +179,10 @@ class BinillaWidget():
             BinillaWidget.ttk_theme = "alt"
 
     def __init__(self, *args, **kwargs):
+        try:
+            self.tk.call("tk", "scaling", str(WIDGET_SCALING))
+        except AttributeError:
+            pass
         self.read_traces = {}
         self.write_traces = {}
         self.undefine_traces = {}


### PR DESCRIPTION
This allows us to globally scale tkinter widgets.

The way this works is that before any widgets are created you should change the WIDGET_SCALING in binilla_widget.

I have not found a good place to implement it yet. But here is the required code.