### PR TITLE
Use os.system in open_in_default_program

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.5]
+### Changed
+ - Fix improper use of start command for windows in util.open_in_default_program.
+
 ## [1.2.4]
 ### Changed
  - Fix readme potentially breaking setup.

--- a/binilla/__init__.py
+++ b/binilla/__init__.py
@@ -3,8 +3,8 @@
 # ##############
 __author__ = "Devin Bobadilla, Michelle van der Graaf"
 #           YYYY.MM.DD
-__date__ = "2020.02.14"
-__version__ = (1, 2, 4)
+__date__ = "2020.02.15"
+__version__ = (1, 2, 5)
 __website__ = "https://github.com/Sigmmma/binilla"
 __all__ = (
     'defs', 'widgets', 'windows',

--- a/binilla/util.py
+++ b/binilla/util.py
@@ -133,15 +133,15 @@ def open_in_default_program(path):
     '''
     try:
         if e_c.IS_MAC:
-            subprocess.Popen(['open', str(path)])
+            os.system('open "%s"' % path)
         elif e_c.IS_LNX:
-            subprocess.Popen(['xdg-open', str(path)])
+            os.system('xdg-open "%s"' % path)
         else:
             if Path(path).is_dir():
                 # windows does not properly open directories using "start".
                 # we have to directly call explorer in this case
-                subprocess.Popen(['explorer', str(path)])
+                os.system('explorer "%s"' % path)
             else:
-                subprocess.Popen(['start', str(path)])
+                os.system('start "%s"' % path)
     except Exception:
         print(format_exc())

--- a/binilla/util.py
+++ b/binilla/util.py
@@ -142,6 +142,6 @@ def open_in_default_program(path):
                 # we have to directly call explorer in this case
                 os.system('explorer "%s"' % path)
             else:
-                os.system('start "%s"' % path)
+                os.system('start "" "%s"' % path)
     except Exception:
         print(format_exc())

--- a/binilla/util.py
+++ b/binilla/util.py
@@ -142,6 +142,6 @@ def open_in_default_program(path):
                 # we have to directly call explorer in this case
                 os.system('explorer "%s"' % path)
             else:
-                os.system('start "" "%s"' % path)
+                os.system('start /B "" "%s"' % path)
     except Exception:
         print(format_exc())


### PR DESCRIPTION
This should fix Python not understanding that start is a system command.