### PR TITLE
Print parsing errors regardless of handler.debug

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3]
+### Changed
+ - Parsing errors now do print, even if handler.debug is not true.
+
 ## [1.3.2]
 ### Changed
  - Fix python 3.5 specific save as bug.

--- a/binilla/__init__.py
+++ b/binilla/__init__.py
@@ -3,8 +3,8 @@
 # ##############
 __author__ = "Sigmmma"
 #           YYYY.MM.DD
-__date__ = "2020.05.11"
-__version__ = (1, 3, 2)
+__date__ = "2020.06.21"
+__version__ = (1, 3, 3)
 __website__ = "https://github.com/Sigmmma/binilla"
 __all__ = (
     'defs', 'widgets', 'windows',

--- a/binilla/app_window.py
+++ b/binilla/app_window.py
@@ -1243,8 +1243,7 @@ class Binilla(tk.Tk, BinillaWidget):
                           "Could not load: %s" % path)
                     continue
                 except Exception:
-                    if handler.debug:
-                        print(format_exc())
+                    print(format_exc())
                     print("Could not load: %s" % path)
                     continue
 


### PR DESCRIPTION
My reasoning for this is because otherwise it will just print
```
Could not load: X
You might need to change the tag set to load these tag(s).
```

Which was really undescriptive and has no doubt hidden a lot of errors from us before.