### PR TITLE
fix bug where tags can’t be saved on Python 3.9

### DIFF
--- a/binilla/windows/tag_window.py
+++ b/binilla/windows/tag_window.py
@@ -644,8 +644,8 @@ class TagWindow(tk.Toplevel, BinillaWidget):
             while True:
                 save_thread.join(0.05)
                 self.update()
-                # NOTE TO SELF: isAlive is a method, NOT a decorated property...
-                if not save_thread.isAlive():
+                # NOTE TO SELF: is_alive is a method, NOT a decorated property...
+                if not save_thread.is_alive():
                     break
 
             self.field_widget.set_edited(False)


### PR DESCRIPTION
Saving a tag on Python 3.9 currently fails with:

```
Backing up to: 'c:\program files (x86)\steam\steamapps\common\chelan_1\tags\backup\characters\cyborg\cyborg.model_animations'
Traceback (most recent call last):
  File "C:\Users\delan\opt\MEK\mek_lib\binilla\app_window.py", line 1447, in save_tag
    w.save()
  File "C:\Users\delan\opt\MEK\mek_lib\mozzarilla\windows\tag_window.py", line 42, in save
    TagWindow.save(self, **kwargs)
  File "C:\Users\delan\opt\MEK\mek_lib\binilla\windows\tag_window.py", line 664, in save
    raise exception
  File "C:\Users\delan\opt\MEK\mek_lib\binilla\windows\tag_window.py", line 648, in save
    if not save_thread.isAlive():
AttributeError: 'Thread' object has no attribute 'isAlive'

Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\tkinter\__init__.py", line 1892, in __call__
    return self.func(*args)
  File "C:\Users\delan\opt\MEK\mek_lib\binilla\app_window.py", line 1362, in save
    self.save_tag()
  File "C:\Users\delan\opt\MEK\mek_lib\mozzarilla\app_window.py", line 915, in save_tag
    return Binilla.save_tag(self, tag)
  File "C:\Users\delan\opt\MEK\mek_lib\binilla\app_window.py", line 1453, in save_tag
    raise IOError("Could not save tag.")
OSError: Could not save tag.
```

This is essentially because Thread.isAlive was renamed to Thread.is_alive. The new name was added [in Python 2.6](https://docs.python.org/2/library/threading.html#threading.Thread.is_alive), then the old name was removed from the docs [in Python 3.0](https://docs.python.org/3.0/library/threading.html#threading.Thread.is_alive), then it was removed entirely [in Python 3.9](https://docs.python.org/3/whatsnew/3.9.html#removed). Thankfully that means our minimum of Python 3.5 won’t need to change.